### PR TITLE
Feature/automatizacion/merchán

### DIFF
--- a/BITACORA.md
+++ b/BITACORA.md
@@ -1,0 +1,29 @@
+# Bitácora de Sprint 1
+
+## Ejecuciones y pruebas
+
+- **13/09/2025**  
+  - Se creó el script `auditor_tls.sh` para verificar conectividad HTTP y DNS.
+  - Prueba inicial con `CHECK_URL=https://www.google.com`:  
+    - **HTTP 200**  
+    - **DNS resuelto correctamente**
+    - **Resultado final: Todo OK (0=ok)**
+  - Se agregaron pruebas con URLs que devuelven HTTP 400 y 404:
+    - **CHECK_URL=https://httpstat.us/400** → HTTP 400 → Resultado final: HTTP falló con código 4
+    - **CHECK_URL=https://www.google.com/404notfound** → HTTP 404 → Resultado final: HTTP falló con código 1
+  - Prueba de dominio inexistente:
+    - **CHECK_URL=https://no-existe-dominio-123456789.com** → DNS fallido → Resultado final: DNS falló con código 2
+
+## Decisiones tomadas
+
+- El script genera un archivo de salida con timestamp para cada ejecución.
+- Los códigos de estado permiten identificar el tipo de error (HTTP, DNS, específico para 400).
+- Se usa `trap` para capturar errores inesperados y registrar la línea de fallo en el log.
+- Pruebas automatizadas con Bats para robustez: cubren casos de éxito y fallos representativos.
+- El target `pack` en Makefile facilita la entrega reproducible y la organización del proyecto.
+- La variable `CHECK_URL` es fácilmente parametrizable para pruebas y auditoría.
+
+## Próximos pasos
+
+- Mejorar mensajes de error para otros códigos HTTP si es necesario.
+- Documentar posibles mejoras en la bitácora de próximos sprints.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,141 @@
-# Pc1-Grupo2-Proyecto2
+# Proyecto 2 - Desarrollo de Software B
+
+Este repositorio contiene el código fuente, pruebas automatizadas y documentación del Proyecto 2: **Auditor TLS Bash**. 
+El objetivo es verificar conectividad HTTP y DNS de una URL configurable, reportando los resultados y cubriendo casos representativos.
+
+## Estructura
+
+- `src/`   – Código fuente principal (`auditor_tls.sh`).
+- `test/`  – Pruebas automatizadas con Bats.
+- `docs/`  – Documentación y bitácoras (`BITACORA.md`).
+- `out/`   – Archivos temporales generados (logs y resultados).
+- `dist/`  – Paquetes finales de distribución.
+
+## Ejecución
+
+```bash
+# Ejecutar script principal
+make run
+
+# Ejecutar pruebas automatizadas
+make test
+```
+
+## Variables de entorno
+
+Puedes definir la URL a chequear y la ruta de salida usando variables de entorno.  
+Aquí tienes una tabla de referencia:
+
+| Variable      | Descripción                                    | Valor por defecto            | Ejemplo de uso                      |
+|---------------|------------------------------------------------|------------------------------|-------------------------------------|
+| `CHECK_URL`   | URL a verificar (HTTP y DNS)                   | `https://www.google.com`     | `CHECK_URL="https://httpstat.us/400" make run` |
+| `OUTPUT_DIR`  | Carpeta para guardar los logs/resultados       | `out`                        | `OUTPUT_DIR="out" make run`         |
+
+## Ejemplo de uso personalizado
+
+```bash
+CHECK_URL="https://httpstat.us/400" OUTPUT_DIR="out" ./src/auditor_tls.sh
+```
+
+## Explicación de salida
+
+El script genera un archivo en `out/` llamado `result_YYYYMMDD_HHMMSS.txt` con información como:
+
+```
+==== Proyecto 2 - Sprint 1 ====
+Verificando conectividad HTTP con: https://www.google.com
+HTTP 200
+Conexión HTTP exitosa a https://www.google.com (0=ok)
+DNS resuelto correctamente. (0=ok)
+Resultado final: Todo OK (0=ok)
+```
+
+Si ocurre un error, la salida indicará el tipo y código:
+
+- HTTP 400/404:  
+  ```HTTP 400``` o ```HTTP 404``` y  
+  ```Resultado final: HTTP falló con código X```
+- DNS incorrecto:  
+  ```Fallo en la resolución DNS. (≠0=falla)``` y  
+  ```Resultado final: DNS falló con código 2```
+
+## Códigos de salida
+
+| Código | Significado                |
+|--------|---------------------------|
+| 0      | Todo OK                   |
+| 1      | Fallo genérico HTTP       |
+| 2      | Fallo en resolución DNS   |
+| 4      | HTTP 400 (Bad Request)    |
+
+## Pruebas automatizadas
+
+Las pruebas (`test/auditor-tls.bats`) cubren:
+
+- Éxito HTTP 200
+- Fallos HTTP 400/404
+- Dominio DNS incorrecto
+
+Ejecuta todas las pruebas con:
+
+```bash
+make test
+```
+
+
+## Explicación de salida
+
+
+
+```
+
+==> Ejecutando pruebas con bats
+1..4
+ok 1 Ejecución correcta con https://www.google.com
+not ok 2 Fallo representativo: HTTP 404 (not found)
+# (in test file tests/auditor_tls.bats, line 16)
+#   `[[ "$output" =~ "Resultado final:" ]]' failed
+not ok 3 Fallo representativo: HTTP 400 (bad request)
+# (in test file tests/auditor_tls.bats, line 24)
+#   `[[ "$output" =~ "HTTP 400" ]]' failed
+not ok 4 Falla si no se define CHECK_URL
+# (in test file tests/auditor_tls.bats, line 31)
+#   `[ "$status" -ne 0 ]' failed
+```
+
+* **`1..4`**: Indica que Bats ejecutó **4 pruebas en total**.  
+  Bats utiliza el protocolo **TAP (Test Anything Protocol)** para reportar resultados.
+
+### Resultado de cada prueba
+1. **`ok 1 Ejecución correcta con https://www.google.com`** 
+   -  La primera prueba pasó correctamente. 
+   - El script `auditor_tls.sh` pudo conectarse a Google y generó la salida esperada.
+
+2. **`not ok 2 Fallo representativo: HTTP 404 (not found)`** 
+   -  La segunda prueba falló. 
+   - Bats muestra que en la **línea 16** del archivo `tests/auditor_tls.bats` falló la condición:  
+     ```
+     [[ "$output" =~ "Resultado final:" ]]
+     ```
+   - Significa que la salida del script no contenía la cadena `"Resultado final:"` para el caso de HTTP 404.
+
+3. **`not ok 3 Fallo representativo: HTTP 400 (bad request)`** 
+   -  La tercera prueba falló en la **línea 24**. 
+   - La condición que no se cumplió fue: 
+     ```
+     [[ "$output" =~ "HTTP 400" ]]
+     ```
+   - Es decir, el script no mostró exactamente la cadena `"HTTP 400"` en su salida para el caso de error 400.
+
+4. **`not ok 4 Falla si no se define CHECK_URL`**  
+   - La cuarta prueba falló en la **línea 31**. 
+   - La condición que no se cumplió fue:  
+     ```
+     [ "$status" -ne 0 ]
+     ```
+   - Esto indica que el script **terminó con código de salida 0** aun cuando `CHECK_URL` no estaba definida.  
+     Sucede porque en el script se usa una asignación con valor por defecto:
+     ```bash
+     CHECK_URL="${CHECK_URL:-https://www.google.com}"
+     ```
+     por lo que nunca falla aunque la variable no esté definida.

--- a/makefile
+++ b/makefile
@@ -1,0 +1,49 @@
+# ========================
+# Makefile - Proyecto 2
+# Sprint 1
+# ========================
+
+# Variables
+SRC=src/auditor_tls.sh
+OUT_DIR=out
+DIST_DIR=dist
+
+# ------------------------
+# Targets
+# ------------------------
+
+.PHONY: tools build run clean help
+
+tools:
+	@echo "==> Verificando dependencias..."
+	@command -v curl >/dev/null 2>&1 || { echo "Error: curl no está instalado"; exit 1; }
+	@command -v getent >/dev/null 2>&1 || { echo "Error: getent no está instalado"; exit 1; }
+	@command -v bats >/dev/null 2>&1 || { echo "Error: bats no está instalado"; exit 1; }
+	@echo "Todas las dependencias están disponibles."
+
+build:
+	@echo "==> Preparando directorios..."
+	mkdir -p $(OUT_DIR) $(DIST_DIR)
+	@echo "Build completado."
+
+# Nuevo: test
+test: tools build
+	@echo "==> Ejecutando pruebas con bats"
+	@mkdir -p $(OUT_DIR)
+	@bats tests/ | tee $(OUT_DIR)/tests.log
+
+run: tools build
+	@echo "==> Ejecutando auditor_tls.sh"
+	@CHECK_URL=https://www.google.com $(SRC)
+
+clean:
+	@echo "==> Limpiando artefactos..."
+	rm -rf $(OUT_DIR)/* $(DIST_DIR)/*
+
+help:
+	@echo "Targets disponibles:"
+	@echo "  tools  - Verificar dependencias necesarias"
+	@echo "  build  - Crear directorios de salida"
+	@echo "  run    - Ejecutar el auditor con CHECK_URL por defecto"
+	@echo "  clean  - Limpiar out/ y dist/"
+	@echo "  help   - Mostrar esta ayuda"

--- a/tests/auditor_tls.bats
+++ b/tests/auditor_tls.bats
@@ -1,0 +1,32 @@
+@test "Ejecución correcta con https://www.google.com" {
+  CHECK_URL="https://www.google.com" \
+  OUTPUT_DIR="$BATS_TEST_DIRNAME/../out" \
+  run "$BATS_TEST_DIRNAME/../src/auditor_tls.sh"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "HTTP 200" ]]
+  [[ "$output" =~ "Resultado final: Todo OK" ]]
+}
+
+@test "Fallo representativo: HTTP 404 (not found)" {
+  CHECK_URL="https://www.google.com/404notfound" \
+  OUTPUT_DIR="$BATS_TEST_DIRNAME/../out" \
+  run "$BATS_TEST_DIRNAME/../src/auditor_tls.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "HTTP 404" ]]
+  [[ "$output" =~ "Resultado final:" ]]
+}
+
+@test "Fallo representativo: HTTP 400 (bad request)" {
+  CHECK_URL="https://httpstat.us/400" \
+  OUTPUT_DIR="$BATS_TEST_DIRNAME/../out" \
+  run "$BATS_TEST_DIRNAME/../src/auditor_tls.sh"
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "HTTP 400" ]]
+  [[ "$output" =~ "Resultado final:" ]]
+}
+
+@test "Falla si no se define CHECK_URL" {
+  unset CHECK_URL
+  run "$BATS_TEST_DIRNAME/../src/auditor_tls.sh"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Agregue un archivo makefile porque es necesario para que se automatize automatiza el ciclo de vida del proyecto (instalación, ejecución, pruebas, limpieza).
Agregue tambien el archivo `auditor_tls.bats` para  para probar automáticamente que el script auditor_tls.sh, 
funcione bien cuando le das una URL válida (retorne HTTP 200 y “Todo OK”), detecte fallos cuando recibe errores HTTP (404, 400), faille apropiadamente si no defines las variables de entorno