### PR TITLE
añadi target test con soporte Bats y documentacion en help

### DIFF
--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ DIST_DIR=dist
 # Targets
 # ------------------------
 
-.PHONY: tools build run clean help
+.PHONY: tools build run clean help test
 
 tools:
 	@echo "==> Verificando dependencias..."
@@ -26,7 +26,6 @@ build:
 	mkdir -p $(OUT_DIR) $(DIST_DIR)
 	@echo "Build completado."
 
-# Nuevo: test
 test: tools build
 	@echo "==> Ejecutando pruebas con bats"
 	@mkdir -p $(OUT_DIR)
@@ -44,6 +43,7 @@ help:
 	@echo "Targets disponibles:"
 	@echo "  tools  - Verificar dependencias necesarias"
 	@echo "  build  - Crear directorios de salida"
+	@echo "  test   - Ejecutar pruebas con BATS y guardar log en out/"
 	@echo "  run    - Ejecutar el auditor con CHECK_URL por defecto"
 	@echo "  clean  - Limpiar out/ y dist/"
 	@echo "  help   - Mostrar esta ayuda"


### PR DESCRIPTION
### Cambios realizados
- Se añadió el target 'test' al makefile para ejecutar pruebas con Bats.
- Se actualizó la sección '.PHONY' para incluir 'test'.
- Se mejoró la ayuda (make help) documentando el nuevo target.
- Los resultados de las pruebas se guardan automáticamente en 'out/tests.log'.