### PR TITLE
Feature/automatizacion/merchan

### DIFF
--- a/docs/bitacora-sprint-2.md
+++ b/docs/bitacora-sprint-2.md
@@ -1,8 +1,8 @@
-# Bitacora sprint 2
-## **Objetivo:** Comprobar el estado de los puertos de los servidores auditados.
+# Bitacora sprint 2 
+##  Comprobar el estado de los puertos de los servidores auditados.
 
 ## 1. Error al ejecutar en Git Bash
-- Al ejecutar el archivo `auditor_tls.sh` en Git Bash saltaba el siguiente error: "Error: falta la herramienta 'getent'".
+- Al ejecutar el `auditor_tls.sh` en Git Bash saltaba el siguiente error: "Error: falta la herramienta 'getent'".
 - Esto sucede debido a que Git Bash no incluye todas las utilidades de Linux.
 - **Solucion:** Ejecutamos en WSL, donde `getnet` si esta disponible.
 
@@ -31,3 +31,22 @@ DNS resuelto correctamente. (0=ok)
 ss: No se encontraron sockets con puerto 44444 y estado LISTEN (≠0=falla)
 nc: Puerto 44444 NO accesible en www.google.com (timeout/conn refused) (≠0=falla)
 Resultado final: ss detectó ausencia de sockets esperados (código 5)
+
+
+
+## Simular politicas de permiso y guia para consultar logs
+
+## 1. Creacion de la funcion perm_sandbox_setup
+- Se crea la funcion con el proposito de aplicar una umask configurable (027 por defecto) y analizar los permisos que reda a los nuevos directorios y archivos que se crearan.
+- Crea un directorio temporal `SANDBOX_DIR` y un archivo `probe.txt` con el proposito de evaluar sus permisos. Luego estos seran borrados, pero quedara registro en el journal.
+- Comando clave `stat -c %a %n` nos muestra los permisos con codigo octal y el nombre del directorio/archivo evaluado.
+- Se crea la funcion complemetaria `perm_sandbox_teardown` que nos ayudara a borrar el directorio temporal.
+
+## 2. Registro de log's en Journal
+- Actualizamos la funcion `log` que ahora imprime el valor de salida en: consola, archivo de salida y en Journal. Comando clave `logger -t auditor_tls` registra los logs en el script.
+
+## 3. Guia rapida para consultas en el Journal
+- Los mensajes enviados al Journal pueden revisarse con `journalctl -t auditor_tls` para ver todos los registros, o `journalctl -t auditor_tls --since "2 min ago"` para ver los registros de los ultimos 2 minutos. 
+- Tambien podemos hacerlo la revision por lineas `journalctl -t auditor_tls -n 20` que nos imprime las ultimas 20 lineas, o `journalctl -t auditor_tls -n 20 --no-pager` para los registros esten en un solo bloque y no en paginas.
+
+

--- a/src/auditor_tls.sh
+++ b/src/auditor_tls.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# -----------------------
-# Configuración inicial
+# ------------------------
+# Configuración inicial del auditor
 # -----------------------
 CHECK_URL="${CHECK_URL:-https://www.google.com}"
-# dirname me dirige a la carpeta donde se encuentra "auditor.sh"
-# y lo guarda ../out en la carpeta out fuera de src.
 OUTPUT_DIR="$(dirname "$0")/../out" 
 OUTPUT_FILE="$OUTPUT_DIR/result_$(date +%Y%m%d_%H%M%S).txt"
 
+TARGET_PORT="${TARGET_PORT:-443}"   # Por defecto HTTPS (443). Sobreescribe TARGET_PORT=####
+
+# Nuevos: politica de permisos
+PERM_UMASK="${PERM_UMASK:-027}"                    # umask documentada (p. ej. 027: dir 750, file 640)
+PERM_SANDBOX_PARENT="${PERM_SANDBOX_PARENT:-"$OUTPUT_DIR"}" # dónde crear sandbox temporal
+
+# Journal logging
+JOURNAL_TAG="${JOURNAL_TAG:-auditor_tls}"  # tag de logger: journalctl -t auditor_tls
+REQUIRE_LOGGER="${REQUIRE_LOGGER:-0}"      # 1=exigir logger; 0=opcional
+
+# -----------------------
+# Funciones log (implementa a Journal) y require
 # Puerto objetivo: por defecto HTTPS (443). Se puede sobrescribir con TARGET_PORT=####
 TARGET_PORT="${TARGET_PORT:-443}"
 
@@ -22,7 +32,13 @@ trap 'echo "Error inesperado en la línea $LINENO" | tee -a "$OUTPUT_FILE"' ERR
 # Funciones log y require
 # -----------------------
 log() {
-    echo "$1" | tee -a "$OUTPUT_FILE"
+    local msg="$*"                  # Toma uno o más argumentos de entrada
+    echo "$msg"                     # Imprime en consola
+    echo "$msg" >> "$OUTPUT_FILE"   # Guarda en archivo de salida
+    # Manda al journal si logger existe
+    if command -v logger >/dev/null 2>&1; then
+        logger -t "$JOURNAL_TAG" -- "$msg"
+    fi
 }
 
 require() {  # <--- NUEVO: valida herramientas presentes
@@ -110,6 +126,61 @@ check_port_nc() {
     fi
 }
 
+# ------------------------------------------------
+# NUEVO: sandbox de permisos con umask documentado
+# ------------------------------------------------
+perm_sandbox_setup() {
+  local old_umask
+  old_umask=$(umask)
+  umask "$PERM_UMASK"        # aplica política de permisos simulada
+
+  # Crea sandbox temporal (carpeta de trabajo con esa umask)
+  SANDBOX_DIR="$(mktemp -d -p "$PERM_SANDBOX_PARENT" auditor_sbx.XXXXXX)"
+  # Crea un archivo para evidenciar máscaras (permisos heredados)
+  : > "$SANDBOX_DIR/probe.txt"
+
+  # Muestra permisos efectivos (evidencia)
+  local dperm fperm
+  dperm="$(stat -c '%a %n' "$SANDBOX_DIR")"
+  fperm="$(stat -c '%a %n' "$SANDBOX_DIR/probe.txt")"
+  log "SANDBOX creada: $SANDBOX_DIR (umask=$PERM_UMASK)"
+  log "Permisos sandbox: $dperm ; archivo: $fperm"
+
+  # Restaura umask original para no afectar al resto del script
+  umask "$old_umask"
+}
+
+perm_sandbox_teardown() {
+  # Limpieza al salir
+  if [[ -n "${SANDBOX_DIR:-}" && -d "$SANDBOX_DIR" ]]; then
+    rm -rf -- "$SANDBOX_DIR"
+    log "SANDBOX eliminada: $SANDBOX_DIR"
+  fi
+}
+
+# -----------------------
+# Manejo de errores global
+# -----------------------
+trap 'log "Error inesperado en la línea $LINENO"; perm_sandbox_teardown' ERR    # Se guarda en el Journal y borramos la Sandbox
+trap 'perm_sandbox_teardown' EXIT
+
+# -----------------------
+# NUEVO: Check para permisos de escritura
+# -----------------------
+check_write_dir() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    log "Directorio no existe: $dir (≠0=falla)"
+    return 7
+  fi
+  if [[ ! -w "$dir" ]]; then
+    log "Permisos insuficientes: no puedo escribir en $dir (≠0=falla)"
+    return 8
+  fi
+  return 0
+}
+
+
 # -----------------------
 # Ejecución principal
 # -----------------------
@@ -117,6 +188,9 @@ require curl
 require getent
 require ss
 require nc
+require logger      # Para acceder al journal
+
+perm_sandbox_setup
 
 log "==== Proyecto 2 - Sprint 1 ===="
 log "Verificando conectividad HTTP con: $CHECK_URL"
@@ -128,6 +202,29 @@ http_status=$?
 
 check_dns "$host"
 dns_status=$?
+
+check_write_dir "$OUTPUT_DIR"
+write_status=$?
+
+# -----------------------
+# NUEVO: Validaciones de puertos
+# -----------------------
+# 1) ss: inspección de sockets por puerto/estado (LOCAL / host actual)
+#    Nota: Esto valida que en *tu máquina* hay sockets con ese puerto y estado.
+#    Para servicios remotos, 'ss' es menos útil; se deja como evidencia de uso de ss.
+check_ss_status="LISTEN"   # puedes parametrizarlo con SS_STATE=LISTEN/ESTABLISHED
+if check_port_ss "localhost" "$TARGET_PORT" "${SS_STATE:-$check_ss_status}"; then
+    ss_status=0
+else
+    ss_status=$?
+fi
+
+# 2) nc: reachability del puerto 443 (o TARGET_PORT) en el host extraído de la URL (REMOTO)
+if check_port_nc "$host" "$TARGET_PORT"; then
+    nc_status=0
+else
+    nc_status=$?
+fi
 
 # -----------------------
 # NUEVO: Validaciones de puertos
@@ -164,6 +261,9 @@ elif [ "$ss_status" -ne 0 ]; then
 elif [ "$nc_status" -ne 0 ]; then
     log "Resultado final: nc no pudo conectarse a $host:$TARGET_PORT (código $nc_status)"
     exit "$nc_status"
+elif [ "$write_status" -ne 0 ]; then
+    log "Resultado final: permisos insuficientes en $OUTPUT_DIR (código $write_status)"
+    exit "$write_status"
 else
     log "Resultado final: Todo OK (0=ok)"
     exit 0

--- a/videos del proyecto.txt
+++ b/videos del proyecto.txt
@@ -1,0 +1,2 @@
+sprint 1:
+https://www.youtube.com/watch?v=60_Ljux4i98

--- a/videos.txt
+++ b/videos.txt
@@ -1,3 +1,3 @@
+Video con exposicion del sprint1:
 
-Video del sprint1:
 https://www.youtube.com/watch?v=60_Ljux4i98

--- a/videos.txt
+++ b/videos.txt
@@ -1,0 +1,3 @@
+
+Video del sprint1:
+https://www.youtube.com/watch?v=60_Ljux4i98


### PR DESCRIPTION
Se logro incorporar simulación de permisos y registro de logs con journalctl y simular política de permisos y exponer guía para consultar logs generados por la ejecución. Hubo una creación de un directorio temporal con umask documentado para evidenciar permisos. Tambien se hizo una guía en docs/bitacora-sprint-2.md que muestre uso de journalctl -u <servicio> o equivalente (cuando aplique). El script informa claramente si carece de permisos para escribir en el directorio.
