### PR TITLE
Procesar y filtrar resultados TLS con toolkit Unix (sort, uniq, tr)

### DIFF
--- a/docs/bitacora-sprint-3.md
+++ b/docs/bitacora-sprint-3.md
@@ -49,3 +49,50 @@ Paquete creado en dist/Pc1-Grupo2-Proyecto2-v1.0.0.tar.gz
 - `make pack` genera un archivo en `dist/` con `Nombre del proyecto`-`version` y reproducible.
 - `make test` ejecuta los bats y falla si algunno falla.
 - Se documento el uso en `docs/readme.md`
+
+
+
+### **Procesamiento y filtrado de resultados TLS (`sort`, `uniq`, `tr`)**
+
+Se actualizó el script para incluir una nueva función: **`generar_reporte_tls`**, cuyo objetivo es **generar un reporte legible de configuraciones TLS auditadas**.  
+
+Este reporte se guarda automáticamente en la carpeta `out/` con un nombre que incluye la **fecha y hora de ejecución**.  
+
+#### 🔹 Criterios de aceptación implementados:
+- **Uso de `sort` y `uniq`**:  
+  Se aplican sobre la salida de `ss` y `getent hosts` para **eliminar duplicados y ordenar resultados**, evitando confusión en el reporte.  
+
+- **Uso de `tr`**:  
+  Convierte todo a **minúsculas**, de modo que los datos tengan un formato uniforme y más fácil de comparar.  
+
+- **Reporte final**:  
+  Guardado en `out/reporte-TLS-<fecha>.txt`, garantizando trazabilidad de cada ejecución.  
+
+####  Ejemplo de reporte generado:
+
+```
+==== REPORTE TLS ====
+Host: www.google.com
+Fecha: Fri Sep 19 20:11:59 CDT 2025
+
+>> Conexiones SS (ordenadas y únicas)
+netid state     recv-q send-q  local address:port    peer address:portprocess
+tcp   listen    0      1000   10.255.255.254:53           0.0.0.0:*          
+tcp   listen    0      4096             [::]:9000            [::]:*          
+tcp   listen    0      4096             [::]:9870            [::]:*          
+tcp   listen    0      4096          0.0.0.0:9000         0.0.0.0:*          
+tcp   listen    0      4096          0.0.0.0:9870         0.0.0.0:*          
+tcp   listen    0      4096        127.0.0.1:43129        0.0.0.0:*          
+tcp   listen    0      4096       127.0.0.54:53           0.0.0.0:*          
+tcp   listen    0      4096    127.0.0.53%lo:53           0.0.0.0:*          
+tcp   time-wait 0      0       172.22.75.112:58514 172.217.28.164:443        
+tcp   time-wait 0      0       172.22.75.112:58530 172.217.28.164:443        
+udp   unconn    0      0               [::1]:323             [::]:*          
+udp   unconn    0      0           127.0.0.1:323          0.0.0.0:*          
+udp   unconn    0      0          127.0.0.54:53           0.0.0.0:*          
+udp   unconn    0      0       127.0.0.53%lo:53           0.0.0.0:*          
+udp   unconn    0      0      10.255.255.254:53           0.0.0.0:*          
+
+>> Resolución DNS
+172.217.28.164  www.google.com
+```


### PR DESCRIPTION
Generar un reporte legible de configuraciones TLS auditadas.

Criterios de aceptación:

Uso de sort y uniq para eliminar duplicados en las salidas.

Uso de tr para formatear campos (por ejemplo, convertir mayúsculas/minúsculas).

Guardar reporte final en out/ con fecha en el nombre.

